### PR TITLE
Fix export CSV headers to include prompt JSON data

### DIFF
--- a/backend/app/routes/export.py
+++ b/backend/app/routes/export.py
@@ -37,8 +37,21 @@ async def export_generations(session: AsyncSession = Depends(get_session)):
         CachedResponse.text,
     ).order_by(CachedResponse.id)
     rows = (await session.execute(q)).all()
-    header = ["participant_id","task_id","condition","response_id","model",
-              "tokens_in","tokens_out","latency_ms","created_at","prompt_text","text"]
+    header = [
+        "participant_id",
+        "task_id",
+        "condition",
+        "response_id",
+        "model",
+        "tokens_in",
+        "tokens_out",
+        "latency_ms",
+        "created_at",
+        "system_prompt",
+        "user_prompt",
+        "prompt_text",
+        "text",
+    ]
     return StreamingResponse(_to_csv(rows, header),
         media_type="text/csv",
         headers={"Content-Disposition": "attachment; filename=generations.csv"}

--- a/backend/generations.csv
+++ b/backend/generations.csv
@@ -1,4 +1,4 @@
-participant_id,task_id,condition,response_id,model,tokens_in,tokens_out,latency_ms,created_at,prompt_text,text
+participant_id,task_id,condition,response_id,model,tokens_in,tokens_out,latency_ms,created_at,system_prompt,user_prompt,prompt_text,text
 dev-user-1,A7,baseline,1dbbd66e-3629-4a0b-8d2c-1ac422041a32,gpt-4o-mini-2024-07-18,842,287,5515,2025-09-17 12:39:28,"You have the following personality on a fixed 10–50 scale (10 = very low, 50 = very high): 
 Openness: 42; 
 Conscientiousness: 26; 

--- a/backend/tests/test_export.py
+++ b/backend/tests/test_export.py
@@ -1,0 +1,52 @@
+import asyncio
+import csv
+
+from app.routes.export import export_generations
+
+
+class DummyResult:
+    def __init__(self, rows):
+        self._rows = rows
+
+    def all(self):
+        return self._rows
+
+
+class DummySession:
+    def __init__(self, rows):
+        self._rows = rows
+
+    async def execute(self, _query):
+        return DummyResult(self._rows)
+
+
+def test_export_generations_includes_prompts():
+    row = (
+        "participant-1",
+        "task-1",
+        "baseline",
+        "resp-1",
+        "gpt-test",
+        10,
+        20,
+        30,
+        "2024-01-01T00:00:00",
+        "system",
+        "user",
+        "Prompt body",
+        '{"answer":"value"}',
+    )
+
+    async def call_export():
+        response = await export_generations(session=DummySession([row]))
+        chunks = []
+        async for chunk in response.body_iterator:
+            chunks.append(chunk)
+        return "".join(chunks)
+
+    csv_payload = asyncio.run(call_export())
+    reader = list(csv.reader(csv_payload.splitlines()))
+    header, data = reader[0], reader[1]
+
+    assert header[9:13] == ["system_prompt", "user_prompt", "prompt_text", "text"]
+    assert data[9:13] == ["system", "user", "Prompt body", '{"answer":"value"}']


### PR DESCRIPTION
## Summary
- add system and user prompt columns to the generations export so CSV headers match the streamed data
- refresh the example generations.csv header to include the new columns
- add a regression test to ensure the export includes the prompt columns and JSON output

## Testing
- PYTHONPATH=backend DATABASE_URL=sqlite+aiosqlite:///backend/study.db pytest backend/tests/test_export.py


------
https://chatgpt.com/codex/tasks/task_e_68cabfb807848326bfae33ce6f80043a